### PR TITLE
Update librarian puppet git URL to https instead of git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "librarian-puppet", :git => "https://github.com/garethr/librarian-puppet", :branch => "forge-release-candidates"
+gem "librarian-puppet"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "librarian-puppet", :git => "git://github.com/garethr/librarian-puppet.git", :branch => "forge-release-candidates"
+gem "librarian-puppet", :git => "https://github.com/garethr/librarian-puppet", :branch => "forge-release-candidates"


### PR DESCRIPTION
Hi,

For those behind a firewall blocking port 22 git: urls don't work.
I updated the librarian puppet repo URL to use https to get around this.

Thanks,
Csaba
