### PR TITLE
Made 2 changes to manifests/base.pp

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -34,6 +34,12 @@ node 'attacker' {
   class { 'ntp':
     autoupdate => true,
   }
+  
+  exec { "apt-update":
+    command => "/usr/bin/apt-get update"
+  }
+
+  Exec["apt-update"] -> Package <| |>
 
   class { 'ruby':
     ruby_package     => 'ruby1.9.1-full',

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -134,7 +134,7 @@ node 'attacker' {
   }
 
   wget::fetch { 'download owasp zap':
-    source      => 'https://zaproxy.googlecode.com/files/ZAP_2.2.0_Linux.tar.gz',
+    source      => 'http://jaist.dl.sourceforge.net/project/zaproxy/2.3.1/ZAP_2.3.1_Linux.tar.gz',
     destination => '/opt/src/zap.tar.gz',
     require     => File['/opt/src'],
     before      => Exec['untar and move owasp zap'],


### PR DESCRIPTION
1.) Updated the download URL for ZAProxy to point to its new Sourceforge home, rather than Google Code.

2.) Configured apt-get update to run first on the attacker node, as package installs were failing with 404 errors.
