### PR TITLE
Add libffi-dev package

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -15,6 +15,7 @@ node 'attacker' {
     'python-nltk',
     'python-pip',
     'libcurl4-gnutls-dev',
+    'libffi-dev',
     'libopenssl-ruby',
   ]:
     ensure => installed,


### PR DESCRIPTION
This is required for pyOpenSSL to build (via pip).

The errors presented are:

No package 'libffi' found

compiling '_configtest.c':

__thread int some_threadlocal_variable_42;

gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -c _configtest.c -o _configtest.o

success!

removing: _configtest.c _configtest.o

c/_cffi_backend.c:13:17: fatal error: ffi.h: No such file or directory
